### PR TITLE
feat&chore: code-generation changes & improvements

### DIFF
--- a/code-generator/src/main/kotlin/io/timemates/rsproto/codegen/FileTransformer.kt
+++ b/code-generator/src/main/kotlin/io/timemates/rsproto/codegen/FileTransformer.kt
@@ -29,7 +29,11 @@ internal object FileTransformer {
                 addImport("io.ktor.utils.io.core", "readBytes")
             }
 
-            addTypes(protoFile.types.map { TypeTransformer.transform(it, schema) })
+            val types = protoFile.types.map { TypeTransformer.transform(it, schema) }
+
+            types.mapNotNull(TypeTransformer.Result::constructorFun)
+                .forEach(::addFunction)
+            addTypes(types.map { it.typeSpec })
         }.build()
     }
 }

--- a/code-generator/src/main/kotlin/io/timemates/rsproto/codegen/types/EnclosingTypeTransformer.kt
+++ b/code-generator/src/main/kotlin/io/timemates/rsproto/codegen/types/EnclosingTypeTransformer.kt
@@ -7,12 +7,20 @@ import com.squareup.wire.schema.EnclosingType
 import com.squareup.wire.schema.Schema
 
 internal object EnclosingTypeTransformer {
+
     fun transform(incoming: EnclosingType, schema: Schema): TypeSpec {
+        val nested = incoming.nestedTypes.map { TypeTransformer.transform(it, schema) }
+
         return TypeSpec.classBuilder(incoming.name)
             .primaryConstructor(
                 FunSpec.constructorBuilder().addModifiers(KModifier.PRIVATE).build()
             )
-            .addTypes(incoming.nestedTypes.map { TypeTransformer.transform(it, schema) })
+            .addType(
+                TypeSpec.companionObjectBuilder()
+                    .addFunctions(nested.mapNotNull(TypeTransformer.Result::constructorFun))
+                    .build()
+            )
+            .addTypes(nested.map(TypeTransformer.Result::typeSpec))
             .build()
     }
 

--- a/code-generator/src/main/kotlin/io/timemates/rsproto/codegen/types/EnumTypeTransformer.kt
+++ b/code-generator/src/main/kotlin/io/timemates/rsproto/codegen/types/EnumTypeTransformer.kt
@@ -8,6 +8,8 @@ import io.timemates.rsproto.codegen.Types
 
 internal object EnumTypeTransformer {
     fun transform(incoming: EnumType, schema: Schema): TypeSpec {
+        val nested = incoming.nestedTypes.map { TypeTransformer.transform(it, schema) }
+
         return TypeSpec.enumBuilder(incoming.name)
             .addAnnotation(Annotations.OptIn(Types.experimentalSerializationApi))
             .addAnnotation(Annotations.Serializable)
@@ -20,8 +22,13 @@ internal object EnumTypeTransformer {
                             .build()
                     )
                 }
-            }.addTypes(incoming.nestedTypes.map { TypeTransformer.transform(it, schema) })
+            }
+            .addTypes(nested.map(TypeTransformer.Result::typeSpec))
+            .addType(
+                TypeSpec.companionObjectBuilder()
+                    .addFunctions(nested.mapNotNull(TypeTransformer.Result::constructorFun))
+                    .build()
+            )
             .build()
     }
-
 }

--- a/code-generator/src/main/kotlin/io/timemates/rsproto/codegen/types/TypeTransformer.kt
+++ b/code-generator/src/main/kotlin/io/timemates/rsproto/codegen/types/TypeTransformer.kt
@@ -1,14 +1,18 @@
 package io.timemates.rsproto.codegen.types
 
+import com.squareup.kotlinpoet.FunSpec
 import com.squareup.kotlinpoet.TypeSpec
 import com.squareup.wire.schema.*
 
 internal object TypeTransformer {
-    fun transform(incoming: Type, schema: Schema): TypeSpec {
+    data class Result(val typeSpec: TypeSpec, val constructorFun: FunSpec?)
+
+    fun transform(incoming: Type, schema: Schema): Result {
         return when (incoming) {
             is MessageType -> MessageTypeTransformer.transform(incoming, schema)
-            is EnumType -> EnumTypeTransformer.transform(incoming, schema)
-            is EnclosingType -> EnclosingTypeTransformer.transform(incoming, schema)
+                .let { Result(it.type, it.constructorFun) }
+            is EnumType -> Result(EnumTypeTransformer.transform(incoming, schema), null)
+            is EnclosingType -> Result(EnclosingTypeTransformer.transform(incoming, schema), null)
         }
     }
 


### PR DESCRIPTION
# What's new
- Constructors are now private
- `create` function replaced with fake constructor function
- oneofs are now have non-nullable member with `Default` in companion.

## Is it breaking change?

Yes, as there no more 'create' function. Also, oneofs are now always not-null. If constructors were previously used, it requires migration to variant with lambda builder.

We cannot enforce consumers to use named parameters, and that's why I made private constructors. `create` as a function is not necessary. 
